### PR TITLE
Replaced dead link in "Référence" in /post6.md ("Mémo sur les expressions régulières")

### DIFF
--- a/content/post6.md
+++ b/content/post6.md
@@ -179,7 +179,8 @@ Mais les expressions régulières, c'est surtout l'apanage des ninja sous linux.
 #### Référence
 [openclassrooms.com](http://fr.openclassrooms.com/informatique/cours/concevez-votre-site-web-avec-php-et-mysql/memento-des-expressions-regulieres)   
 [wikipedia](http://fr.wikipedia.org/wiki/Expression_rationnelle)   
-[http://www.expreg.com/](http://www.expreg.com/)   
+[cyrilex](https://extendsclass.com/regex-tester.html)   
+[pyrexp](https://pythonium.net/regex)   
 
 
 


### PR DESCRIPTION
Bonjour,

J'ai remplacé un lien mort vers le site expreg.com par deux autres ressources sur les expressions régulières.